### PR TITLE
FileOutput.seek patch

### DIFF
--- a/asys/FileSystem.hx
+++ b/asys/FileSystem.hx
@@ -39,9 +39,9 @@ class FileSystem {
 				case null: Success({
 					gid: stat.gid,
 					uid: stat.uid,
-					atime: stat.atime,
-					mtime: stat.mtime,
-					ctime: stat.ctime,
+					atime: (cast stat.atime:Date), // FIXME: https://github.com/HaxeFoundation/haxe/issues/7549
+					mtime: (cast stat.mtime:Date), // FIXME: https://github.com/HaxeFoundation/haxe/issues/7549
+					ctime: (cast stat.ctime:Date), // FIXME: https://github.com/HaxeFoundation/haxe/issues/7549
 					size: Std.int(stat.size),
 					dev : stat.dev,
 					ino: Std.int(stat.ino),

--- a/asys/io/FileOutput.hx
+++ b/asys/io/FileOutput.hx
@@ -32,7 +32,7 @@ class FileOutput extends haxe.io.Output {
 
 	public function seek(length: Int, pos: FileSeek)
 		switch pos {
-			case FileSeek.SeekBegin: position = 0;
+			case FileSeek.SeekBegin: position = length;
 			case FileSeek.SeekCur: position += length;
 			case FileSeek.SeekEnd:
 				throw 'Not implemented';


### PR DESCRIPTION
This should patch FileOutput.seek, which currently only sets the position to 0 with FileSeek.SeekBegin

And this should patch writeBytes, which currently overrides bytes starting from position 0 instead of the position of the FileOutput instance.